### PR TITLE
Add Preserve breaks option to keep newline characters

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,16 @@ import { Base85Encoder, Base85Decoder } from "./Base85";
 import { Rot13Encoder, Rot13Decoder } from "./Rot13";
 import { AtbashEncoder, AtbashDecoder } from "./Atbash";
 
+interface CoderSettings {
+	preserveBreaks: boolean;
+}
+
+const DEFAULT_SETTINGS: CoderSettings = {
+	preserveBreaks: false
+}
+
 export default class CoderPlugin extends Plugin {
+	settings: CoderSettings;
 
 	// List of coders
 	coders: Coder[] = [
@@ -21,6 +30,10 @@ export default class CoderPlugin extends Plugin {
 	];
 
 	async onload() {
+		await this.loadSettings();
+
+		this.addSettingTab(new CoderSettingTab(this.app, this));
+
 		this.coders.forEach(coder => {
 		    this.registerMarkdownCodeBlockProcessor(
 		        `transform-${coder.from}-${coder.to}`,
@@ -41,26 +54,70 @@ export default class CoderPlugin extends Plugin {
 	}
 
 	processText(content: string, el: HTMLElement, coder: Coder|null) {
-		var destination;
-
 		if(content.endsWith("\n")) {
 			// Obsidian gives an unpretty linebreak at the end. Don't encode it in our content!
 			content = content.substring(0, content.length - 1);
 		}
 
+		let outputText: string;
+		
 		// convert the content variable to a byte array
 		if(coder != null) {
 			if(coder.checkInput(content)) {
-				destination = document.createTextNode(coder.transform(content));
+				outputText = coder.transform(content);
 			} else {
-				destination = document.createTextNode("Invalid input for coder " + coder.from + " to " + coder.to);
+				outputText = "Invalid input for coder " + coder.from + " to " + coder.to;
 			}
 		} else {
-			destination = document.createTextNode( "No coder found!");
+			outputText = "No coder found!";
 		}
 
-		el.appendChild(destination);
+		// Use <pre> tag if preserveBreaks is enabled to maintain newlines
+		if(this.settings.preserveBreaks) {
+			const pre = document.createElement("pre");
+			pre.textContent = outputText;
+			el.appendChild(pre);
+		} else {
+			const destination = document.createTextNode(outputText);
+			el.appendChild(destination);
+		}
+		
 		return;
+	}
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
+}
+
+class CoderSettingTab extends PluginSettingTab {
+	plugin: CoderPlugin;
+
+	constructor(app: App, plugin: CoderPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const {containerEl} = this;
+
+		containerEl.empty();
+
+		containerEl.createEl('h2', {text: 'Coder Settings'});
+
+		new Setting(containerEl)
+			.setName('Preserve breaks')
+			.setDesc('Preserve newline characters (\\n) in the encoded output')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.preserveBreaks)
+				.onChange(async (value) => {
+					this.plugin.settings.preserveBreaks = value;
+					await this.plugin.saveSettings();
+				}));
 	}
 }
 


### PR DESCRIPTION
Currently, if you have the following code block... 

> [!NOTE]
> The following is using `transform-rot13-text`

```transform-rot13-text
👋 uryyb
🌍 jbeyq
```

It renders something like this...

```
👋 hello 🌍 world
```

But, with this PR, with the "Preserve breaks" option turned on...

<img width="706" height="405" alt="Screenshot 2026-01-06 at 10 01 33 PM" src="https://github.com/user-attachments/assets/10dc9b75-cf88-4c75-a388-c34126ce556d" />

It will render something like this...

```
👋 hello
🌍 world
```
